### PR TITLE
Removing extra worker param

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -15,7 +15,7 @@ export async function hash(
 ): Promise<string> {
   let worker = new Worker(
     new URL("worker.ts", import.meta.url).toString(),
-    { type: "module", deno: true },
+    { type: "module" },
   );
 
   worker.postMessage({
@@ -47,7 +47,7 @@ export async function genSalt(
 ): Promise<string> {
   let worker = new Worker(
     new URL("worker.ts", import.meta.url).toString(),
-    { type: "module", deno: true },
+    { type: "module" },
   );
 
   worker.postMessage({
@@ -80,7 +80,7 @@ export async function compare(
 ): Promise<boolean> {
   let worker = new Worker(
     new URL("worker.ts", import.meta.url).toString(),
-    { type: "module", deno: true },
+    { type: "module" },
   );
 
   worker.postMessage({


### PR DESCRIPTION
I am removing extra worker param which was causing TS2345 errors when using a simple tsconfig.json

```
{
    "compilerOptions": {
        "lib": [
            "dom",
            "es2017",
            "deno.ns",
            "dom.iterable"
        ]
    }
}
```
running: `deno run -A -c .\tsconfig.json .\crypt.ts`
deno 1.2.0
v8 8.5.216
typescript 3.9.2