### PR TITLE
Fix cipher being bypassed when running with Deno 1.23.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         run: deno fmt --check --ignore=./README.md
 
       - name: Run tests
-        run: deno test --unstable --allow-read
+        run: deno test --allow-read --allow-net

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        deno: ["v1.9.0", "v1.x"]
+        deno: ["v1.9.0", "v1.23.0", "v1.x"]
     name: Test run with Deno ${{ matrix.deno }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -4,22 +4,27 @@
 [![release](https://img.shields.io/github/v/release/jamesbroadberry/deno-bcrypt.svg?color=green&label=latest)](https://github.com/JamesBroadberry/deno-bcrypt/releases)
 [![ci](https://github.com/JamesBroadberry/deno-bcrypt/workflows/ci/badge.svg)](https://github.com/JamesBroadberry/deno-bcrypt/actions)
 
-This is a port from [jBCrypt](https://github.com/jeremyh/jBCrypt) to TypeScript for use in [Deno](https://deno.land/).
+This is a port from [jBCrypt](https://github.com/jeremyh/jBCrypt) to TypeScript
+for use in [Deno](https://deno.land/).
 
 It has zero third-party dependencies.
 
-Running in sync requires no permissions.
-Running in async functionality requires --allow-net
+Running in sync requires no permissions. Running in async functionality requires
+--allow-net
 
 ## Import
 
-If you don't want to specify a specific version and are happy to work with breaking changes, you can import this module like so:
+If you don't want to specify a specific version and are happy to work with
+breaking changes, you can import this module like so:
 
 ```ts
 import * as bcrypt from "https://deno.land/x/bcrypt/mod.ts";
 ```
 
-To ensure that you've got a specific version, it's recommend to import this module specifying a [specific release](https://github.com/JamesBroadberry/deno-bcrypt/releases) like so:
+To ensure that you've got a specific version, it's recommend to import this
+module specifying a
+[specific release](https://github.com/JamesBroadberry/deno-bcrypt/releases) like
+so:
 
 ```ts
 import * as bcrypt from "https://deno.land/x/bcrypt@v0.3.0/mod.ts";
@@ -29,7 +34,8 @@ import * as bcrypt from "https://deno.land/x/bcrypt@v0.3.0/mod.ts";
 
 ### Async
 
-The Async implementation requires WebWorkers which require --allow-net to import Deno standard modules from inside the Worker.
+The Async implementation requires WebWorkers which require --allow-net to import
+Deno standard modules from inside the Worker.
 
 ```ts
 const hash = await bcrypt.hash("test");
@@ -50,7 +56,10 @@ const hash = await bcrypt.hash("test", salt);
 
 ### Sync/Blocking
 
-It is not recommended to use this unless you're running a quick script since the BCrypt algorithm is computationally quite expensive. For example, if you're running a server and make multiple calls to it, other requests will be blocked. Using the Async methods are recommended.
+It is not recommended to use this unless you're running a quick script since the
+BCrypt algorithm is computationally quite expensive. For example, if you're
+running a server and make multiple calls to it, other requests will be blocked.
+Using the Async methods are recommended.
 
 To hash a password (with auto-generated salt):
 
@@ -73,9 +82,15 @@ const hash = bcrypt.hashSync("test", salt);
 
 ### Older versions of Deno and/or BCrypt
 
-Older versions of Deno will require an older version of this library (specifically < 0.3.0) because of the introduction of `TextEncoder`.
-However, older version of this library require the `--unstable` flag when running.
+Older versions of Deno will require an older version of this library
+(specifically < 0.3.0) because of the introduction of `TextEncoder`. However,
+older version of this library require the `--unstable` flag when running.
+
+## Warnings
+
+BCrypt v0.3.0 and below should NOT be used with Deno 1.23.0 or later since there's been a [breaking change in how Deno interprets the code](https://github.com/denoland/deno/issues/14900) and completely bypasses the cipher. Ensure that if you're running Deno 1.23.0 or later that you're using the latest version of BCrypt.
 
 ## Issues
 
-For any bug reports or feature requests, please create an issue on [GitHub](https://github.com/JamesBroadberry/deno-bcrypt/issues).
+For any bug reports or feature requests, please create an issue on
+[GitHub](https://github.com/JamesBroadberry/deno-bcrypt/issues).

--- a/src/bcrypt/bcrypt.ts
+++ b/src/bcrypt/bcrypt.ts
@@ -1193,7 +1193,7 @@ function crypt_raw(
   }
 
   for (i = 0; i < 64; i++) {
-    for (j = 0; j < clen >> 1; j++) encipher(cdata, j << 1);
+    for (j = 0; j < (clen >> 1); j++) encipher(cdata, j << 1);
   }
 
   ret = new Uint8Array(clen * 4);

--- a/test/mod.test.ts
+++ b/test/mod.test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.144.0/testing/asserts.ts";
+} from "https://deno.land/std@0.97.0/testing/asserts.ts";
 
 import * as bcrypt from "../mod.ts";
 


### PR DESCRIPTION
Fixes #27 #28

Details about why this broke are in [this issue](https://github.com/denoland/deno/issues/14900) 